### PR TITLE
Support waiting on process groups, tighten signal permissions, and fix select readiness counting

### DIFF
--- a/include/ps/ps.h
+++ b/include/ps/ps.h
@@ -396,6 +396,7 @@ void do_exit(unsigned encoded_status);
 int sys_exit(unsigned status);
 int sys_waitpid(unsigned pid, int *status, int options);
 int do_waitpid(unsigned pid, int *status, int options, rusage *rusage);
+int do_waitpid_pgrp(unsigned pgrp, int *status, int options, rusage *rusage);
 void qemu_exit(unsigned char code);
 char *sys_getcwd(char *buf, unsigned size);
 int sys_getrusage(int who, rusage *usage);

--- a/src/fs/select.c
+++ b/src/fs/select.c
@@ -34,6 +34,7 @@ static int select_ctx_check(void *arg)
 
 	for (i = 0; i < ctx->nfds; i++) {
 		unsigned want = 0;
+		unsigned fd_ready = 0;
 		if (ctx->reads && FD_ISSET(i, ctx->reads))
 			want |= FS_POLL_READ;
 		if (ctx->writes && FD_ISSET(i, ctx->writes))
@@ -45,16 +46,17 @@ static int select_ctx_check(void *arg)
 		unsigned ready_mask = fs_fd_poll(i, want, NULL);
 		if ((want & FS_POLL_READ) && (ready_mask & FS_POLL_READ)) {
 			FD_SET(i, ctx->readfds);
-			ready++;
+			fd_ready = 1;
 		}
 		if ((want & FS_POLL_WRITE) && (ready_mask & FS_POLL_WRITE)) {
 			FD_SET(i, ctx->writefds);
-			ready++;
+			fd_ready = 1;
 		}
 		if ((want & FS_POLL_EXCEPT) && (ready_mask & FS_POLL_EXCEPT)) {
 			FD_SET(i, ctx->exceptfds);
-			ready++;
+			fd_ready = 1;
 		}
+		ready += fd_ready;
 	}
 	return ready;
 }

--- a/src/ps/ps.c
+++ b/src/ps/ps.c
@@ -340,12 +340,10 @@ void ps_send_signal_pgrp(unsigned pgrp, int sig)
 		node = rb_next(node);
 		if (task->type == ps_user && task->user &&
 		    task->user->group_id == pgrp) {
-			spinlock_unlock(&ps_lock, irq);
 			task->signal->sig_pending |= (1UL << (sig - 1));
 			if (task->status == ps_waiting &&
 			    !(task->signal->sig_mask & (1UL << (sig - 1))))
-				ps_put_to_ready_queue(task);
-			spinlock_lock(&ps_lock, &irq);
+				ps_put_to_ready_queue_unsafe(task);
 		}
 	}
 	spinlock_unlock(&ps_lock, irq);

--- a/src/ps/ps_syscall.c
+++ b/src/ps/ps_syscall.c
@@ -309,6 +309,90 @@ done:
 	return ret;
 }
 
+int do_waitpid_pgrp(unsigned pgrp, int *status, int options, rusage *rusage)
+{
+	task_struct *cur = CURRENT_TASK();
+	task_struct *task = NULL;
+	list_entry *dying_task_entry;
+	struct rb_node *node;
+	int ret = -1;
+	int irq;
+	int has_group_child = 0;
+
+	if (TestControl.verbos)
+		klog("wait4(pgrp=%u, %x, %x, %x)\n", pgrp, status, options,
+		     rusage);
+
+	for (;;) {
+		task = NULL;
+		has_group_child = 0;
+		spinlock_lock(&ps_lock, &irq);
+
+		dying_task_entry = control.dying_queue.next;
+		while (dying_task_entry != &control.dying_queue) {
+			task = container_of(dying_task_entry, task_struct,
+					    ps_list);
+			dying_task_entry = dying_task_entry->next;
+			if (task->parent->psid != cur->psid || !task->user ||
+			    task->user->group_id != pgrp)
+				continue;
+
+			has_group_child = 1;
+			ret = task->psid;
+			if (status)
+				*status = task->exit_status;
+
+			list_remove_entry(&task->ps_list);
+			ps_remove_mgr_unsafe(task);
+			cur->nchildren--;
+			goto done;
+		}
+
+		task = NULL;
+		node = rb_first(&control.mgr_queue);
+		while (node) {
+			task_struct *t = rb_entry(node, task_struct, mgr_rb);
+			node = rb_next(node);
+			if (t->parent->psid == cur->psid && t->user &&
+			    t->user->group_id == pgrp) {
+				has_group_child = 1;
+				break;
+			}
+		}
+
+		if (!has_group_child) {
+			ret = -ECHILD;
+			goto done;
+		}
+
+		if (cur->signal->sig_pending & ~cur->signal->sig_mask &
+		    ~(1UL << (SIGCHLD - 1))) {
+			ret = -EINTR;
+			goto done;
+		}
+
+		if (options == WNOHANG) {
+			ret = 0;
+			goto done;
+		}
+
+		ps_put_to_wait_queue_unsafe(cur, NULL, __func__);
+		spinlock_unlock(&ps_lock, irq);
+		task_sched();
+	}
+
+done:
+	spinlock_unlock(&ps_lock, irq);
+
+	if (task)
+		ps_reap_task(task, rusage);
+
+	if (TestControl.verbos)
+		klog("wait4(pgrp=%u) returns %d\n", pgrp, ret);
+
+	return ret;
+}
+
 int sys_waitpid(unsigned pid, int *status, int options)
 {
 	if (TestControl.verbos)

--- a/src/syscall/syscall_proc.c
+++ b/src/syscall/syscall_proc.c
@@ -64,7 +64,27 @@ enum {
 struct kill_all_ctx {
 	task_struct *self;
 	int sig;
+	unsigned pgrp;
+	int sent;
 };
+
+static int can_send_signal(task_struct *sender, task_struct *target)
+{
+	user_enviroment *su, *tu;
+
+	if (!sender || !target || !target->user)
+		return 0;
+
+	su = sender->user;
+	tu = target->user;
+	if (!su)
+		return 0;
+	if (su->euid == 0)
+		return 1;
+
+	return su->uid == tu->uid || su->uid == tu->suid || su->euid == tu->uid ||
+	       su->euid == tu->suid;
+}
 
 static void send_if_other(task_struct *task, void *opaque)
 {
@@ -72,7 +92,20 @@ static void send_if_other(task_struct *task, void *opaque)
 
 	if (task->type != ps_user || task->psid == c->self->psid)
 		return;
-	ps_send_signal(task->psid, c->sig);
+	if (ps_send_signal(task->psid, c->sig) == 0)
+		c->sent++;
+}
+
+static void send_if_pgrp(task_struct *task, void *opaque)
+{
+	struct kill_all_ctx *c = opaque;
+
+	if (task->type != ps_user || !task->user || task->psid == c->self->psid)
+		return;
+	if (task->user->group_id != c->pgrp)
+		return;
+	if (ps_send_signal(task->psid, c->sig) == 0)
+		c->sent++;
 }
 
 int sys_getpid()
@@ -471,7 +504,7 @@ int sys_wait4(int pid, int *status, int options, void *rusage)
 	if (pid == -1)
 		return do_waitpid(0, status, options, rusage);
 	else if (pid < -1)
-		return 0; /* FIXME: wait on group id */
+		return do_waitpid_pgrp((unsigned)(-pid), status, options, rusage);
 	else
 		return do_waitpid(pid, status, options, rusage);
 }
@@ -483,6 +516,7 @@ int sys_wait4(int pid, int *status, int options, void *rusage)
  */
 int ps_send_signal(unsigned pid, int sig)
 {
+	task_struct *sender = CURRENT_TASK();
 	task_struct *target;
 
 	if (sig <= 0 || sig >= NSIG)
@@ -492,10 +526,15 @@ int ps_send_signal(unsigned pid, int sig)
 	if (!target)
 		return -ESRCH;
 
+	if (target->type != ps_user || !target->user || !target->signal) {
+		return -ESRCH;
+	}
+
+	if (!can_send_signal(sender, target))
+		return -EPERM;
+
 	target->signal->sig_pending |= (1UL << (sig - 1));
 
-	/* Wake the target only if the signal is not blocked by its current mask.
-	 * A masked signal stays pending but must not interrupt a sleeping task. */
 	if (target->status == ps_waiting &&
 	    !(target->signal->sig_mask & (1UL << (sig - 1))))
 		ps_put_to_ready_queue(target);
@@ -518,22 +557,36 @@ int sys_kill(int pid, int sig)
 		return ps_send_signal((unsigned)pid, sig);
 
 	if (pid == 0) {
+		struct kill_all_ctx ctx;
 		if (!cur->user)
 			return -ESRCH;
-		ps_send_signal_pgrp(cur->user->group_id, sig);
-		return 0;
+		ctx.self = cur;
+		ctx.sig = sig;
+		ctx.pgrp = cur->user->group_id;
+		ctx.sent = 0;
+		ps_enum_all(send_if_pgrp, &ctx);
+		return ctx.sent ? 0 : -ESRCH;
 	}
 
 	if (pid == -1) {
 		struct kill_all_ctx ctx;
 		ctx.self = cur;
 		ctx.sig = sig;
+		ctx.pgrp = 0;
+		ctx.sent = 0;
 		ps_enum_all(send_if_other, &ctx);
-		return 0;
+		return ctx.sent ? 0 : -ESRCH;
 	}
 
-	ps_send_signal_pgrp((unsigned)(-pid), sig);
-	return 0;
+	{
+		struct kill_all_ctx ctx;
+		ctx.self = cur;
+		ctx.sig = sig;
+		ctx.pgrp = (unsigned)(-pid);
+		ctx.sent = 0;
+		ps_enum_all(send_if_pgrp, &ctx);
+		return ctx.sent ? 0 : -ESRCH;
+	}
 }
 
 int sys_brk(unsigned _top)


### PR DESCRIPTION
### Motivation
- Add support for waiting on process groups (negative pid in `wait4`) and make group-kill behavior correctly report failures when no targets exist.
- Harden signal delivery by validating targets and enforcing sender permission checks in `ps_send_signal`.
- Fix `select()` readiness accounting to avoid double-counting a single file descriptor that is ready for multiple events and avoid unlocking the process lock unnecessarily when waking tasks.

### Description
- Added `do_waitpid_pgrp()` and exported it in `include/ps/ps.h`, and wired it into `sys_wait4()` to handle negative pids (process group waits).
- Implemented `can_send_signal()` and tightened `ps_send_signal()` to validate target tasks, require user targets with a signal structure, and enforce permission checks, returning appropriate errors.
- Reworked group-kill logic to enumerate targets via `ps_enum_all()` with `send_if_pgrp`/`send_if_other`, added a `sent` counter to return `-ESRCH` when no signal was delivered, and updated `sys_kill()` accordingly.
- Updated `ps_send_signal_pgrp()` to keep the process lock held and call `ps_put_to_ready_queue_unsafe()` when waking tasks.
- Fixed `select_ctx_check()` in `src/fs/select.c` to increment the ready count once per file descriptor by introducing a `fd_ready` flag, preventing multiple increments when multiple event types are ready.

### Testing
- Built the project with `make` and the build completed successfully.
- Ran automated process/signal regression tests `tests/kill`, `tests/waitpid`, and `tests/wait4`, and they passed.
- Ran `tests/select` to verify readiness counting and behavior, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5df92aae88326ad58d59d1d12d332)